### PR TITLE
Feat: explicit is_rec parameter

### DIFF
--- a/paddleocr_convert/main.py
+++ b/paddleocr_convert/main.py
@@ -21,9 +21,12 @@ class PaddleOCRModelConvert:
         save_dir: InputType,
         txt_path: Optional[str] = None,
         is_del_raw: bool = False,
+        is_rec: Optional[bool] = None
     ) -> str:
         model_name = Path(model_path).stem
-        is_rec = "rec" in model_name
+        
+        if is_rec is None:
+            is_rec = "rec" in model_name
 
         if is_rec and not txt_path:
             raise ConvertError("Please give the txt url.")


### PR DESCRIPTION
close #16

Added a new optional parameter is_rec to the __call__ method.
When an explicit is_rec value is provided, it is used to determine the model type (recognition model) preferentially.
If not provided, the existing behavior (checking whether the filename contains the substring "rec") is maintained.